### PR TITLE
Some tweaks to the build file

### DIFF
--- a/release/build-common.xml
+++ b/release/build-common.xml
@@ -44,10 +44,14 @@
     <property name="cc" value="/usr/bin/cc"/>
     <property name="lipo" location="/usr/bin/lipo"/>
 
-    <!-- Note: open source JavaNativeFoundation is required to build for arm, see https://github.com/apple/openjdk -->
-
-    <property name="JNFdir" location="${SDKroot}/System/Library/Frameworks/JavaVM.framework/Versions/A/Frameworks"/>
-
+    <!-- 
+      JNFdir specifies the location of Apple's JavaNativeFoundation.framework which can be acquired 
+      at https://github.com/apple/openjdk/tree/xcodejdk14-release/apple/JavaNativeFoundation
+      Build it using Xcode and place the resulting JavaNativeFoundation.framework in the lib folder,
+      or override the JNFdir property to point to a folder that contains your own build of the framework.
+    -->
+    <property name="JNFdir" location="${base}/lib/"/>
+    
     <property name="debug" value="false"/>
     <property name="debugoption" value=""/>
 

--- a/release/build-common.xml
+++ b/release/build-common.xml
@@ -9,7 +9,6 @@
     <!-- A Java 9 or later compiler is required -->
 
     <exec executable="java_home" outputproperty="jdk">
-        <arg value="-F"/>
         <arg value="-v"/>
         <arg value="9+"/>
     </exec>

--- a/release/build-common.xml
+++ b/release/build-common.xml
@@ -198,14 +198,14 @@
                     <arg value="Cocoa"/>
                     <arg line="${additional.jni.frameworks}"/>
 
+                    <arg value="-F${SDKroot}/System/Library/Frameworks/JavaVM.framework/Versions/Current/Frameworks"/>
+                    <arg value="-framework"/>
+                    <arg value="JavaRuntimeSupport"/>
+                    
                     <arg value="-F${JNFdir}"/>
                     <arg value="-framework"/>
                     <arg value="JavaNativeFoundation"/>
-
-                    <arg value="-F${SDKroot}/System/Library/Frameworks"/>
-                    <arg value="-framework"/>
-                    <arg value="JavaRuntimeSupport"/>
-
+                    
                     <arg value="-install_name"/>
                     <arg value="${jniname}.dylib"/>
 

--- a/release/build-common.xml
+++ b/release/build-common.xml
@@ -194,12 +194,13 @@
                     <arg value="Cocoa"/>
                     <arg line="${additional.jni.frameworks}"/>
 
-                    <arg value="-F/${SDKroot}/System/Library/Frameworks/JavaVM.framework/Versions/A/Frameworks"/>
-                    <arg value="-framework"/>
-                    <arg value="JavaRuntimeSupport"/>
                     <arg value="-F${JNFdir}"/>
                     <arg value="-framework"/>
                     <arg value="JavaNativeFoundation"/>
+
+                    <arg value="-F${SDKroot}/System/Library/Frameworks"/>
+                    <arg value="-framework"/>
+                    <arg value="JavaRuntimeSupport"/>
 
                     <arg value="-install_name"/>
                     <arg value="${jniname}.dylib"/>


### PR DESCRIPTION
The original build file didn't work for me for a few reasons. One was that some of the framework paths under the SDK folder didn't exist. This PR also tries to clarify how to get the JavaNativeFoundation framework and where to put it. Finally, some of the framework path parameters needed to be reordered in order to build successfully.