### PR TITLE
Fix `ReusableCompositor.reset()` not clearing `isConfigured`

### DIFF
--- a/src/org/violetlib/jnr/impl/ReusableCompositor.java
+++ b/src/org/violetlib/jnr/impl/ReusableCompositor.java
@@ -248,6 +248,7 @@ public class ReusableCompositor
         this.rasterWidth = rasterWidth;
         this.rasterHeight = rasterHeight;
         this.scaleFactor = scaleFactor;
+        isConfigured = false;
         isEmpty = true;
     }
 


### PR DESCRIPTION
After `reset()`, `ensureConfigured()` would skip buffer reallocation and clearing because `isConfigured` was still `true` from the previous use.