### PR TITLE
Fix progress indicator spinner using unadjusted size

### DIFF
--- a/src/org/violetlib/jnr/aqua/impl/AquaNativePainter.java
+++ b/src/org/violetlib/jnr/aqua/impl/AquaNativePainter.java
@@ -468,7 +468,7 @@ public class AquaNativePainter
             sz = Size.LARGE;
         }
 
-        int size = toSize(g.getSize());
+        int size = toSize(sz);
         int state = toActiveState(g.getState());
         int orientation = toOrientation(g.getOrientation());
         BasicRenderer r = (data, rw, rh, w, h) -> nativePaintProgressIndicator(data, rw, rh, w, h,


### PR DESCRIPTION
The size adjustment for non-small spinners was computed but then ignored, as `g.getSize()` was called again instead of using the adjusted `sz` variable.