### PR TITLE
Prevent `getSliderRenderer` w/h side-effects from leaking out of `getPainter`

### DIFF
--- a/src/org/violetlib/jnr/aqua/impl/AquaNativePainter.java
+++ b/src/org/violetlib/jnr/aqua/impl/AquaNativePainter.java
@@ -492,6 +492,8 @@ public class AquaNativePainter
         }
 
         // NSSlider appears to figure out the orientation from the bounds.
+        // Note: w/h are modified here so that configureLayout picks up the adjusted dimensions.
+        // getPainter() saves and restores w/h to prevent these changes from leaking.
 
         if (sw == SliderWidget.SLIDER_HORIZONTAL || sw == SliderWidget.SLIDER_HORIZONTAL_RIGHT_TO_LEFT) {
             if (h >= w) {

--- a/src/org/violetlib/jnr/aqua/impl/AquaUIPainterBase.java
+++ b/src/org/violetlib/jnr/aqua/impl/AquaUIPainterBase.java
@@ -146,10 +146,19 @@ public abstract class AquaUIPainterBase
     public @NotNull Painter getPainter(@NotNull Configuration g)
       throws UnsupportedOperationException
     {
-        LayoutInfo layoutInfo = uiLayout.getLayoutInfo((LayoutConfiguration) g);
-        Renderer r = getRenderer(g);
-        Painter p = getPainter(layoutInfo, g, r);
-        return customizePainter(p, g, layoutInfo);
+        // Save and restore w/h because getRenderer may adjust them (see getSliderRenderer)
+        // and those adjustments must not leak beyond this call.
+        int savedW = w;
+        int savedH = h;
+        try {
+            LayoutInfo layoutInfo = uiLayout.getLayoutInfo((LayoutConfiguration) g);
+            Renderer r = getRenderer(g);
+            Painter p = getPainter(layoutInfo, g, r);
+            return customizePainter(p, g, layoutInfo);
+        } finally {
+            w = savedW;
+            h = savedH;
+        }
     }
 
     protected @NotNull Painter customizePainter(@NotNull Painter p, @NotNull Configuration g, @NotNull LayoutInfo layoutInfo)


### PR DESCRIPTION
`getSliderRenderer()` intentionally modifies the instance w/h fields so that `configureLayout()` uses the adjusted dimensions for the slider. However, these modified values persisted after `getPainter()` returned. Save and restore w/h around the call to prevent state leakage.

In practice I don't think this creates a problem as `configure(w, h)` is always called first, but maybe you'll agree it's nice to tidy up. In this PR: it is a bit weird that the save/restore is in a different method (and class) to the mutation, but it is the best approach I came up with.

